### PR TITLE
Check for pull requests in Appveyor deployment script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,5 @@ install:
 build_script:
   - conda-build .
 
--
-  branches:
-    only:
-      - master
-
-  deploy_script:
-    - ps: .\scripts\deploy_conda.ps1
+deploy_script:
+  - ps: .\scripts\deploy_conda.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,5 +11,10 @@ install:
 build_script:
   - conda-build .
 
-deploy_script:
-  - ps: .\scripts\deploy_conda.ps1
+-
+  branches:
+    only:
+      - master
+
+  deploy_script:
+    - ps: .\scripts\deploy_conda.ps1

--- a/scripts/deploy_conda.ps1
+++ b/scripts/deploy_conda.ps1
@@ -1,6 +1,9 @@
-if (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) {
-   echo "Pull request detected. Aborting deployment..."
-   exit 0
+If (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) {
+    echo "Pull request detected. Aborting deployment..."
+    exit 0
+} ElseIf ($env:APPVEYOR_REPO_BRANCH -ne "master") {
+    echo "Not on master. Aborting deployment..."
+    exit 0
 }
 
 echo "Finding package path..."

--- a/scripts/deploy_conda.ps1
+++ b/scripts/deploy_conda.ps1
@@ -1,5 +1,10 @@
+if (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) {
+   echo "Pull request detected. Aborting deployment..."
+   exit 0
+}
+
 echo "Finding package path..."
-$packagePath = (conda build .\scripts\meta.yaml --output)
+$packagePath = (conda build scripts/meta.yaml --output)
 
 echo "Uploading package..."
 anaconda --token $env:CONDA_TOKEN upload $packagePath

--- a/scripts/meta.yaml
+++ b/scripts/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: leabra7
-  version: 0.0.7
+  version: 0.0.8
 
 source:
   path: ..


### PR DESCRIPTION
Right now, we deploy a Windows package even when we shouldn't (when a pull request is created.) This fixes that scenario by aborting deployment when PULL_REQUEST_NUMBER is defined in the build environment. Fixes #45.